### PR TITLE
Add FSL-1.1-AGPLv3 Template

### DIFF
--- a/FSL-1.1-AGPLv3.template.md
+++ b/FSL-1.1-AGPLv3.template.md
@@ -1,0 +1,84 @@
+# Functional Source License, Version 1.1, AGPLv3 Future License
+
+## Abbreviation
+
+FSL-1.1-AGPLv3
+
+## Notice
+
+Copyright ${year} ${licensor name}
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under these Terms and Conditions, as indicated by our inclusion of these Terms and Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents, Redistribution and Trademark clauses below, we hereby grant you the right to use, copy, modify, create derivative works, publicly perform, publicly display and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use means making the Software available to others in a commercial product or service that:
+
+1. substitutes for the Software;  
+     
+2. substitutes for any other product or service we offer using the Software that exists as of the date we make the Software available; or  
+     
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;  
+     
+2. for non-commercial education;  
+     
+3. for non-commercial research; and  
+     
+4. in connection with professional services that you provide to a licensee using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our patents, the license grant above includes a license under our patents. If you make a claim against any party that the Software infringes or contributes to the infringement of any patent, then your patent license to the Software ends immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software, you must include a copy of or a link to these Terms and Conditions and not remove any copyright notices provided in or with the Software.
+
+### Copy Left
+
+Any modifications or derivative works created by the licensee must be licensed under the same terms as the original agreement. The licensee is required to provide the licensor with copies of such modifications or derivative works, including source code, within 30 days of creation. Additionally, the licensee must ensure that the same terms bind any third party receiving the software or derivative works.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of the Software, you have no right under these Terms and Conditions to use our trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under the GNU Affero General Public License, Version 3.0 that is effective on the second anniversary of the date we make the Software available. On or after that date, you may use the Software under the GNU Affero General Public License, Version 3.0, in which case the following will apply:
+
+This program is free software: you can redistribute it and/or modify  
+it under the terms of the GNU Affero General Public License as published by  
+the Free Software Foundation, either version 3 of the License, or  
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,  
+but WITHOUT ANY WARRANTY; without even the implied warranty of  
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the  
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License  
+along with this program.  If not, see [http://www.gnu.org/licenses/\#AGPL](http://www.gnu.org/licenses/#AGPL).


### PR DESCRIPTION
We would like to use the FSL in combination with the AGPLv3 license (rather than the Apache2 or MIT licenses).

I'm not a lawyer, but I took a stab at creating a license template for this use case and would love feedback on it.

Also curious if others have any interest in this use case or if this use case is even legally feasible?